### PR TITLE
Task17

### DIFF
--- a/include/Ardrivo/OV767X.h
+++ b/include/Ardrivo/OV767X.h
@@ -26,6 +26,7 @@
 enum SMCE_OV767_Format {
     RGB888, // RRRRRRRRGGGGGGGGBBBBBBBB // SMCE extension
     RGB444, // GGGGBBBB----RRRR
+    RGB565, // GGGBBBBB RRRRRGGG
 };
 
 enum SMCE_OV767_Resolution {

--- a/include/SMCE/BoardView.hpp
+++ b/include/SMCE/BoardView.hpp
@@ -208,6 +208,11 @@ class SMCE_API FrameBuffer {
     bool write_rgb444(std::span<const std::byte>);
     /// Copies a frame into a packed buffer of pixels in the format GGGGBBBB0000RRRR
     bool read_rgb444(std::span<std::byte>);
+    
+    /// Copies a frame from a packed buffer of pixels in the format GGGBBBBBRRRRRGGG
+    bool write_rgb565(std::span<const std::byte>);
+    /// Copies a frame into a packed buffer of pixels in the format GGGBBBBBRRRRRGGG
+    bool read_rgb565(std::span<std::byte>);
 };
 
 class SMCE_API FrameBuffers {

--- a/src/Ardrivo/OV767X.cpp
+++ b/src/Ardrivo/OV767X.cpp
@@ -65,6 +65,7 @@ int OV767X::begin(SMCE_OV767_Resolution resolution, SMCE_OV767_Format format, in
     switch (format) {
     case RGB888:
     case RGB444:
+    case RGB565:
         m_format = format;
         break;
     default:
@@ -140,9 +141,10 @@ void OV767X::readFrame(void* buffer) {
         return;
     }
     using ReadType = std::add_const_t<decltype(&smce::FrameBuffer::read_rgb888)>;
-    constexpr ReadType format_read[2] = {
+    constexpr ReadType format_read[3] = {
         &smce::FrameBuffer::read_rgb888,
         &smce::FrameBuffer::read_rgb444,
+        &smce::FrameBuffer::read_rgb565,
     };
     (smce::board_view.frame_buffers[m_key].*format_read[m_format])(
         {static_cast<std::byte*>(buffer), static_cast<std::size_t>(bitsPerPixel() * width() * height() / CHAR_BIT)});

--- a/src/SMCE/BoardView.cpp
+++ b/src/SMCE/BoardView.cpp
@@ -395,11 +395,10 @@ bool FrameBuffer::write_rgb565(std::span<const std::byte> buf) {
     auto* to = frame_buf.data.data();
 
    for (unsigned int i = 0; i < buf.size(); i++) {
-        *to++ = buf[i] & (std::byte)0xF8;
-        *to++ = ((buf[i] & (std::byte)0x7) << 5) |
-                ((buf[i + 1] & (std::byte)0xE0) >> 3); 
+        *to++ = buf[i] & (std::byte)0xF8; //Writing red pixels
+        *to++ = ((buf[i] & (std::byte)0x7) << 5) | ((buf[i + 1] & (std::byte)0xE0) >> 3); //Writing green pixels
         i++;
-        *to++ = (buf[i] & (std::byte)0x1F) << 3;
+        *to++ = (buf[i] & (std::byte)0x1F) << 3; //Writing blue pixels
     }
 
     return true;
@@ -421,9 +420,8 @@ bool FrameBuffer::read_rgb565(std::span<std::byte> buf) {
         std::byte g = *from++;
         std::byte b = *from++;
 
-        buf[i++] = (r & (std::byte)0xF8) | ((g & (std::byte)0xE0) >> 5); 
-        buf[i++] =
-            ((g & (std::byte)0x7) << 5) | ((b & (std::byte)0xF8) >> 3);
+        buf[i++] = (r & (std::byte)0xF8) | ((g & (std::byte)0xE0) >> 5); //writing start of list rrrrrggg 
+        buf[i++] = ((g & (std::byte)0x7) << 5) | ((b & (std::byte)0xF8) >> 3); //writing tail of list gggbbbbb
     }
     return true;
 }

--- a/src/SMCE/BoardView.cpp
+++ b/src/SMCE/BoardView.cpp
@@ -395,11 +395,11 @@ bool FrameBuffer::write_rgb565(std::span<const std::byte> buf) {
     auto* to = frame_buf.data.data();
 
    for (unsigned int i = 0; i < buf.size(); i++) {
-        *to++ = buf[i] & (std::byte)0b11111000;
-        *to++ = ((buf[i] & (std::byte)0b00000111) << 5) |
-                ((buf[i + 1] & (std::byte)0b11100000) >> 3); 
+        *to++ = buf[i] & (std::byte)0xF8;
+        *to++ = ((buf[i] & (std::byte)0x7) << 5) |
+                ((buf[i + 1] & (std::byte)0xE0) >> 3); 
         i++;
-        *to++ = (buf[i] & (std::byte)0b00011111) << 3;
+        *to++ = (buf[i] & (std::byte)0x1F) << 3;
     }
 
     return true;
@@ -421,9 +421,9 @@ bool FrameBuffer::read_rgb565(std::span<std::byte> buf) {
         std::byte g = *from++;
         std::byte b = *from++;
 
-        buf[i++] = (r & (std::byte)0b11111000) | ((g & (std::byte)0b11100000) >> 5); 
+        buf[i++] = (r & (std::byte)0xF8) | ((g & (std::byte)0xE0) >> 5); 
         buf[i++] =
-            ((g & (std::byte)0b00000111) << 5) | ((b & (std::byte)0b11111000) >> 3);
+            ((g & (std::byte)0x7) << 5) | ((b & (std::byte)0xF8) >> 3);
     }
     return true;
 }

--- a/src/SMCE/BoardView.cpp
+++ b/src/SMCE/BoardView.cpp
@@ -395,12 +395,11 @@ bool FrameBuffer::write_rgb565(std::span<const std::byte> buf) {
     auto* to = frame_buf.data.data();
 
    for (unsigned int i = 0; i < buf.size(); i++) {
-        *to++ = buf[i] & (std::byte)0b11111000; // r (rrrrr... -> rrrrr000)
+        *to++ = buf[i] & (std::byte)0b11111000;
         *to++ = ((buf[i] & (std::byte)0b00000111) << 5) |
-                ((buf[i + 1] & (std::byte)0b11100000) >> 3); // g (.....ggg ggg..... -> gggggg00)
-        // Got to do i++ after since i might be unsequencedly modified otherwise
+                ((buf[i + 1] & (std::byte)0b11100000) >> 3); 
         i++;
-        *to++ = (buf[i] & (std::byte)0b00011111) << 3; // b (...bbbbb -> bbbbb000)
+        *to++ = (buf[i] & (std::byte)0b00011111) << 3;
     }
 
     return true;
@@ -418,14 +417,13 @@ bool FrameBuffer::read_rgb565(std::span<std::byte> buf) {
     
     const auto* from = frame_buf.data.data();
     for (unsigned int i = 0; i < buf.size();) {
-        // First byte is red, second green and third blue in RGB888
         std::byte r = *from++;
         std::byte g = *from++;
         std::byte b = *from++;
 
-        buf[i++] = (r & (std::byte)0b11111000) | ((g & (std::byte)0b11100000) >> 5); // rrrrrrrr gggggggg -> rrrrrggg
+        buf[i++] = (r & (std::byte)0b11111000) | ((g & (std::byte)0b11100000) >> 5); 
         buf[i++] =
-            ((g & (std::byte)0b00000111) << 5) | ((b & (std::byte)0b11111000) >> 3); // gggggggg bbbbbbbb -> gggbbbbb
+            ((g & (std::byte)0b00000111) << 5) | ((b & (std::byte)0b11111000) >> 3);
     }
     return true;
 }

--- a/test/BoardView.cpp
+++ b/test/BoardView.cpp
@@ -265,6 +265,8 @@ TEST_CASE("BoardView RGB565 cvt", "[BoardView]") {
     REQUIRE(fb.exists());
 
     {
+
+        //used framework from RGB444 test, increasing the excepted output pixel accordingly
         constexpr std::size_t height = 1;
         constexpr std::size_t width = 1;
 

--- a/test/BoardView.cpp
+++ b/test/BoardView.cpp
@@ -247,101 +247,93 @@ TEST_CASE("BoardView RGB444 cvt", "[BoardView]") {
 }
 
 TEST_CASE("BoardView RGB565 cvt", "[BoardView]") {
-     smce::Toolchain tc{SMCE_PATH};
-     REQUIRE(!tc.check_suitable_environment());
-     smce::Sketch sk{SKETCHES_PATH "noop", {.fqbn = "arduino:avr:nano"}};
-     const auto ec = tc.compile(sk);
-     if (ec)
-         std::cerr << tc.build_log().second;
-     REQUIRE_FALSE(ec);
-     smce::Board br{};
-     REQUIRE(br.configure({.frame_buffers = {{}}}));
-     REQUIRE(br.attach_sketch(sk));
-     REQUIRE(br.prepare());
-     auto bv = br.view();
-     REQUIRE(bv.valid());
-     REQUIRE(br.start());
-     REQUIRE(br.suspend());
-     auto fb = bv.frame_buffers[0];
-     REQUIRE(fb.exists());
+    smce::Toolchain tc{SMCE_PATH};
+    REQUIRE(!tc.check_suitable_environment());
+    smce::Sketch sk{SKETCHES_PATH "noop", {.fqbn = "arduino:avr:nano"}};
+    const auto ec = tc.compile(sk);
+    if (ec)
+        std::cerr << tc.build_log().second;
+    REQUIRE_FALSE(ec);
+    smce::Board br{};
+    REQUIRE(br.configure({.frame_buffers = {{}}}));
+    REQUIRE(br.attach_sketch(sk));
+    REQUIRE(br.start());
+    auto bv = br.view();
+    REQUIRE(bv.valid());
+    REQUIRE(br.suspend());
+    auto fb = bv.frame_buffers[0];
+    REQUIRE(fb.exists());
 
-     // Changing frequency works
-     REQUIRE_FALSE(fb.get_freq() == 10);
-     fb.set_freq(10);
-     REQUIRE(fb.get_freq() == 10);
+    {
+        constexpr std::size_t height = 1;
+        constexpr std::size_t width = 1;
 
-     {
-         constexpr std::size_t height = 1;
-         constexpr std::size_t width = 1;
+        constexpr std::array in = {'\xBC'_b, '\x0A'_b};
+        constexpr std::array expected_out = {'\xB8'_b, '\x80'_b, '\x50'_b};
+        static_assert(in.size() == expected_out.size() / 3 * 2);
 
-         constexpr std::array in = {'\x65'_b, '\x8C'_b};
-         constexpr std::array expected_out = {'\x30'_b, '\x34'_b, '\x30'_b};
-         static_assert(in.size() == expected_out.size() / 3 * 2);
+        fb.set_height(height);
+        fb.set_width(width);
+        REQUIRE(fb.write_rgb565(in));
 
-         fb.set_height(height);
-         fb.set_width(width);
-         REQUIRE(fb.write_rgb565(in));
+        std::array<std::byte, std::size(expected_out)> out;
+        REQUIRE(fb.read_rgb888(out));
+        REQUIRE(out == expected_out);
+    }
 
-         std::array<std::byte, std::size(expected_out)> out;
-         REQUIRE(fb.read_rgb888(out));
-         REQUIRE(out == expected_out);
-     }
+    {
+        constexpr std::size_t height = 2;
+        constexpr std::size_t width = 2;
 
-     {
-         constexpr std::size_t height = 2;
-         constexpr std::size_t width = 2;
+        constexpr std::array in = {'\x23'_b, '\xF1'_b, '\x56'_b, '\xF4'_b, '\x89'_b, '\xF7'_b, '\xBC'_b, '\xFA'_b};
+        constexpr std::array expected_out = {'\x20'_b, '\x7C'_b, '\x88'_b, '\x50'_b, '\xDC'_b, '\xA0'_b,
+                                             '\x88'_b, '\x3C'_b, '\xB8'_b, '\xB8'_b, '\x9C'_b, '\xD0'_b};
+        static_assert(in.size() == expected_out.size() / 3 * 2);
 
-         constexpr std::array in = {'\x65'_b, '\x8C'_b, '\x65'_b, '\x8C'_b, '\x65'_b, '\x8C'_b, '\x65'_b, '\x8C'_b};
-         constexpr std::array expected_out = {'\x30'_b, '\x34'_b, '\x30'_b, '\x30'_b, '\x34'_b, '\x30'_b,
-                                              '\x30'_b, '\x34'_b, '\x30'_b, '\x30'_b, '\x34'_b, '\x30'_b};
-         static_assert(in.size() == expected_out.size() / 3 * 2);
+        fb.set_height(height);
+        fb.set_width(width);
+        fb.write_rgb565(in);
 
-         fb.set_height(height);
-         fb.set_width(width);
-         fb.write_rgb565(in);
+        std::array<std::byte, std::size(expected_out)> out;
+        fb.read_rgb888(out);
+        REQUIRE(out == expected_out);
+    }
 
-         std::array<std::byte, std::size(expected_out)> out;
-         fb.read_rgb888(out);
-         REQUIRE(out == expected_out);
-     }
+    {
+        constexpr std::size_t height = 1;
+        constexpr std::size_t width = 1;
 
-     {
-         constexpr std::size_t height = 1;
-         constexpr std::size_t width = 1;
+        constexpr std::array in = {'\xAD'_b, '\xBE'_b, '\xCF'_b};
+        constexpr std::array expected_out = {'\xAD'_b, '\xD9'_b};
+        static_assert(expected_out.size() == in.size() / 3 * 2);
 
-         constexpr std::array in = {'\x34'_b, '\x34'_b, '\x34'_b};
-         constexpr std::array expected_out = {'\x65'_b, '\x8C'_b};
-         static_assert(expected_out.size() == in.size() / 3 * 2);
+        fb.set_height(height);
+        fb.set_width(width);
+        REQUIRE(fb.write_rgb888(in));
 
-         fb.set_height(height);
-         fb.set_width(width);
-         REQUIRE(fb.write_rgb888(in));
+        std::array<std::byte, std::size(expected_out)> out;
+        REQUIRE(fb.read_rgb565(out));
+        REQUIRE(out == expected_out);
+    }
 
-         std::array<std::byte, std::size(expected_out)> out;
-         REQUIRE(fb.read_rgb565(out));
-         REQUIRE(out == expected_out);
-     }
+    {
+        constexpr std::size_t height = 2;
+        constexpr std::size_t width = 2;
 
-     {
-         constexpr std::size_t height = 2;
-         constexpr std::size_t width = 2;
+        constexpr std::array in = {'\x1A'_b, '\x2B'_b, '\x3C'_b, '\x4D'_b, '\x5E'_b, '\x6F'_b,
+                                   '\x7A'_b, '\x8B'_b, '\x9C'_b, '\xAD'_b, '\xBE'_b, '\xCF'_b};
+        constexpr std::array expected_out = {'\x19'_b, '\x67'_b, '\x4A'_b, '\xCD'_b,
+                                             '\x7C'_b, '\x73'_b, '\xAD'_b, '\xD9'_b};
+        static_assert(expected_out.size() == in.size() / 3 * 2);
 
-         constexpr std::array in = {'\x34'_b, '\x34'_b, '\x34'_b, '\x34'_b, '\x34'_b, '\x34'_b,
-                                    '\x34'_b, '\x34'_b, '\x34'_b, '\x34'_b, '\x34'_b, '\x34'_b};
-         constexpr std::array expected_out = {'\x65'_b, '\x8C'_b, '\x65'_b, '\x8C'_b,
-                                              '\x65'_b, '\x8C'_b, '\x65'_b, '\x8C'_b};
-         static_assert(expected_out.size() == in.size() / 3 * 2);
+        fb.set_height(height);
+        fb.set_width(width);
+        fb.write_rgb888(in);
 
-         fb.set_height(height);
-         fb.set_width(width);
-         fb.write_rgb888(in);
+        std::array<std::byte, std::size(expected_out)> out;
+        fb.read_rgb565(out);
+        REQUIRE(out == expected_out);
+    }
 
-         std::array<std::byte, std::size(expected_out)> out;
-         fb.read_rgb565(out);
-         REQUIRE(out == expected_out);
-     }
-
-
-
-     REQUIRE(br.stop());
- }
+    REQUIRE(br.stop());
+}

--- a/test/BoardView.cpp
+++ b/test/BoardView.cpp
@@ -245,3 +245,103 @@ TEST_CASE("BoardView RGB444 cvt", "[BoardView]") {
 
     REQUIRE(br.stop());
 }
+
+TEST_CASE("BoardView RGB565 cvt", "[BoardView]") {
+     smce::Toolchain tc{SMCE_PATH};
+     REQUIRE(!tc.check_suitable_environment());
+     smce::Sketch sk{SKETCHES_PATH "noop", {.fqbn = "arduino:avr:nano"}};
+     const auto ec = tc.compile(sk);
+     if (ec)
+         std::cerr << tc.build_log().second;
+     REQUIRE_FALSE(ec);
+     smce::Board br{};
+     REQUIRE(br.configure({.frame_buffers = {{}}}));
+     REQUIRE(br.attach_sketch(sk));
+     REQUIRE(br.prepare());
+     auto bv = br.view();
+     REQUIRE(bv.valid());
+     REQUIRE(br.start());
+     REQUIRE(br.suspend());
+     auto fb = bv.frame_buffers[0];
+     REQUIRE(fb.exists());
+
+     // Changing frequency works
+     REQUIRE_FALSE(fb.get_freq() == 10);
+     fb.set_freq(10);
+     REQUIRE(fb.get_freq() == 10);
+
+     {
+         constexpr std::size_t height = 1;
+         constexpr std::size_t width = 1;
+
+         constexpr std::array in = {'\x65'_b, '\x8C'_b};
+         constexpr std::array expected_out = {'\x30'_b, '\x34'_b, '\x30'_b};
+         static_assert(in.size() == expected_out.size() / 3 * 2);
+
+         fb.set_height(height);
+         fb.set_width(width);
+         REQUIRE(fb.write_rgb565(in));
+
+         std::array<std::byte, std::size(expected_out)> out;
+         REQUIRE(fb.read_rgb888(out));
+         REQUIRE(out == expected_out);
+     }
+
+     {
+         constexpr std::size_t height = 2;
+         constexpr std::size_t width = 2;
+
+         constexpr std::array in = {'\x65'_b, '\x8C'_b, '\x65'_b, '\x8C'_b, '\x65'_b, '\x8C'_b, '\x65'_b, '\x8C'_b};
+         constexpr std::array expected_out = {'\x30'_b, '\x34'_b, '\x30'_b, '\x30'_b, '\x34'_b, '\x30'_b,
+                                              '\x30'_b, '\x34'_b, '\x30'_b, '\x30'_b, '\x34'_b, '\x30'_b};
+         static_assert(in.size() == expected_out.size() / 3 * 2);
+
+         fb.set_height(height);
+         fb.set_width(width);
+         fb.write_rgb565(in);
+
+         std::array<std::byte, std::size(expected_out)> out;
+         fb.read_rgb888(out);
+         REQUIRE(out == expected_out);
+     }
+
+     {
+         constexpr std::size_t height = 1;
+         constexpr std::size_t width = 1;
+
+         constexpr std::array in = {'\x34'_b, '\x34'_b, '\x34'_b};
+         constexpr std::array expected_out = {'\x65'_b, '\x8C'_b};
+         static_assert(expected_out.size() == in.size() / 3 * 2);
+
+         fb.set_height(height);
+         fb.set_width(width);
+         REQUIRE(fb.write_rgb888(in));
+
+         std::array<std::byte, std::size(expected_out)> out;
+         REQUIRE(fb.read_rgb565(out));
+         REQUIRE(out == expected_out);
+     }
+
+     {
+         constexpr std::size_t height = 2;
+         constexpr std::size_t width = 2;
+
+         constexpr std::array in = {'\x34'_b, '\x34'_b, '\x34'_b, '\x34'_b, '\x34'_b, '\x34'_b,
+                                    '\x34'_b, '\x34'_b, '\x34'_b, '\x34'_b, '\x34'_b, '\x34'_b};
+         constexpr std::array expected_out = {'\x65'_b, '\x8C'_b, '\x65'_b, '\x8C'_b,
+                                              '\x65'_b, '\x8C'_b, '\x65'_b, '\x8C'_b};
+         static_assert(expected_out.size() == in.size() / 3 * 2);
+
+         fb.set_height(height);
+         fb.set_width(width);
+         fb.write_rgb888(in);
+
+         std::array<std::byte, std::size(expected_out)> out;
+         fb.read_rgb565(out);
+         REQUIRE(out == expected_out);
+     }
+
+
+
+     REQUIRE(br.stop());
+ }


### PR DESCRIPTION
Added RGB565 in BoardView 
Added readRGB565 and writeRGB565, which copies a frame into a packed buffer of pixels in the format GGGBBBBBRRRRRGGG, to BoardView.cpp and BoardView.hpp. 
Added RGB565 to OV767X.cpp and OV767X.hpp SMCE formatting and framebuffer as well so it is usable. 
Added test case for RGB565 to boardView tests
Added test case for RGB565 in test/BoardView.cpp which was built on already implemented test case for RGB444 but changing the number of required bits per 2 bytes from 12 (4+4+4) to 16 (5+6+5) to its expected output.